### PR TITLE
Day 06: Recently-Used List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All Notable changes to `zeravcic\tdd-by-john-cleary` project will be documented 
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.6.0] - 2017-01-02
+### Added
+- src/day06/README.md
+- src/day06/DuplicateItemException.php
+- src/day06/EmptyItemException.php
+- src/day06/RecentlyUsedList.php
+- tests/day06/RecentlyUsedListTest.php
+
+### Changed
+- src/day05/README.md
+
 ## [0.5.0] - 2017-01-02
 ### Added
 - src/day05/README.md
@@ -58,6 +69,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 -  Day-01 - SRC and TEST
 
+[0.6.0]: https://github.com/zeravcic/tdd-by-john-cleary/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/zeravcic/tdd-by-john-cleary/compare/v0.4.1...v0.5.0
 [0.4.1]: https://github.com/zeravcic/tdd-by-john-cleary/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/zeravcic/tdd-by-john-cleary/compare/v0.3.0...v0.4.0

--- a/src/day05/README.md
+++ b/src/day05/README.md
@@ -5,43 +5,24 @@ Write a program that prints the numbers from 1 to 100. But for multiples of thre
 Sample output:
 
 1
-
 2
-
 Fizz
-
 4
-
 Buzz
-
 Fizz
-
 7
-
 8
-
 Fizz
-
 Buzz
-
 11
-
 Fizz
-
 13
-
 14
-
 FizzBuzz
-
 16
-
 17
-
 Fizz
-
 19
-
 Buzz
 
 … etc up to 100

--- a/src/day06/DuplicateItemException.php
+++ b/src/day06/DuplicateItemException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+
+namespace Zeravcic\TddByJohnCleary\day06;
+
+
+/**
+ * Class RecentlyUsedList
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+class DuplicateItemException extends \Exception
+{
+}

--- a/src/day06/EmptyItemException.php
+++ b/src/day06/EmptyItemException.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+
+namespace Zeravcic\TddByJohnCleary\day06;
+
+
+/**
+ * Class RecentlyUsedList
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+class EmptyItemException extends \Exception
+{
+}

--- a/src/day06/README.md
+++ b/src/day06/README.md
@@ -1,0 +1,13 @@
+# Day 6: Recently-Used List
+
+Develop a recently-used-list class to hold strings uniquely in Last-In-First-Out order.
+
+* A recently-used-list is initially empty.
+* The most recently added item is first, the least recently added item is last.
+* Items can be looked up by index, which counts from zero.
+* Items in the list are unique, so duplicate insertions are moved rather than added.
+
+Optional extras:
+
+* Null insertions (empty strings) are not allowed.
+* A bounded capacity can be specified, so there is an upper limit to the number of items contained, with the least recently added items dropped on overflow.

--- a/src/day06/RecentlyUsedList.php
+++ b/src/day06/RecentlyUsedList.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+
+namespace Zeravcic\TddByJohnCleary\day06;
+
+
+/**
+ * Class RecentlyUsedList
+ *
+ * @package Zeravcic\TddByJohnCleary\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ * @see     Zeravcic\TddByJohnCleary\day06\Test\RecentlyUsedListTest::class
+ */
+class RecentlyUsedList
+{
+    /**
+     * List with read stuff LIFO type
+     * @var array
+     */
+    private $readList = array();
+
+    /**
+     * List capacity
+     * @var
+     */
+    private $capacity;
+
+    /**
+     * Position
+     * @var
+     */
+    private $position;
+
+    /**
+     * Construct ReadLust with capacity
+     * @param $capacity
+     */
+    public function __construct($capacity = false)
+    {
+        $this->capacity = $capacity;
+        $this->position = 0;
+    }
+
+    /**
+     * Is ReadList empty
+     * @return bool
+     */
+    public function isEmpty()
+    {
+        return empty($this->readList);
+    }
+
+    /**
+     * Add item into ReadList
+     * @param $item
+     * @throws \Zeravcic\TddByJohnCleary\day06\DuplicateItemException
+     * @throws \Zeravcic\TddByJohnCleary\day06\EmptyItemException
+     */
+    public function add($item)
+    {
+        if (empty($item))
+        {
+            throw new EmptyItemException('Item can\'t be empty.');
+        }
+        if (in_array($item, $this->readList))
+        {
+            throw new DuplicateItemException('Can\'t have duplicate items in list');
+        }
+        $this->readList[] = $item;
+    }
+    /**
+     * Read and remove item from list
+     * LIFO
+     * @return string
+     */
+
+    public function read()
+    {
+        if (($position = count($this->readList)) == 0)
+        {
+            return '';
+        }
+        $read = $this->readList[$position - 1];
+        unset($this->readList[$position - 1]);
+        return $read;
+    }
+
+    /**
+     * Read and remove item from list
+     * @param $index
+     * @return bool
+     */
+    public function getByIndex($index)
+    {
+        if (array_key_exists($index, $this->readList))
+        {
+            $read = $this->readList[$index];
+            unset($this->readList[$index]);
+            return $read;
+        }
+        return false;
+    }
+}

--- a/tests/day06/RecentlyUsedListTest.php
+++ b/tests/day06/RecentlyUsedListTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Created by PhpStorm.
+ *
+ * PHP version 5.6, 7
+ *
+ * @package Zeravcic\TddByJohnCleary\Test\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ */
+
+namespace Zeravcic\TddByJohnCleary\Tests\day06;
+
+use PHPUnit\Framework\TestCase;
+use Zeravcic\TddByJohnCleary\day06\RecentlyUsedList;
+
+// require_once __DIR__ . "/../../src/day06/RecentlyUsedList.php";
+
+/**
+ * Class RecentlyUsedListTest
+ *
+ * @package Zeravcic\TddByJohnCleary\Test\day06
+ * @author  Nikola Zeravcic <niks986@gmail.com>
+ * @license <http://opensource.org/licenses/gpl-license.php GPL
+ * @link    http://nikolazeravcic.iz.rs Personal site
+ * @see     Zeravcic\TddByJohnCleary\day06\RecentlyUsedList::class
+ */
+class RecentlyUsedListTest extends TestCase
+{
+    /**
+     * Test is iterator empty at start
+     */
+    public function testIterator()
+    {
+        $list = new RecentlyUsedList(5);
+        $this->assertTrue($list->isEmpty());
+    }
+
+    /**
+     * We test is ReadList act as LIFO list
+     */
+    public function testLifo()
+    {
+        $list = new RecentlyUsedList(5);
+        $this->assertTrue($list->isEmpty());
+        $list->add('First');
+        $list->add('Second');
+        $list->add('Third');
+        $this->assertFalse($list->isEmpty());
+        $this->assertEquals('Third', $list->read());
+        $this->assertEquals('Second', $list->read());
+        $this->assertEquals('First', $list->read());
+        $this->assertTrue($list->isEmpty());
+    }
+
+    /**
+     * We test can we add empty item in Read list
+     * @expectedException \Zeravcic\TddByJohnCleary\day06\EmptyItemException
+     */
+    public function testEmtyItem()
+    {
+        $list = new RecentlyUsedList(5);
+        $list->add('');
+        $list->add(null);
+    }
+
+    /**
+     *  @expectedException \Zeravcic\TddByJohnCleary\day06\DuplicateItemException
+     */
+    public function testDoubleItem()
+    {
+        $list = new RecentlyUsedList(5);
+        $list->add('one');
+        // Double one expected Exception
+        $list->add('one');
+    }
+
+    /**
+     * We test getByIndex method
+     */
+    public function testGetByIndex()
+    {
+        $list = new RecentlyUsedList(5);
+        $this->assertFalse($list->getByIndex(1));
+        $list->add('one');
+        $list->add('two');
+        $list->add('three');
+        $list->add('4');
+        $this->assertFalse($list->getByIndex(9));
+        $this->assertEquals('two', $list->getByIndex(1));
+        $this->assertEquals('4', $list->getByIndex(3));
+        $this->assertEquals('one', $list->getByIndex(0));
+        $this->assertEquals('three', $list->getByIndex(2));
+        $this->assertTrue($list->isEmpty());
+    }
+}


### PR DESCRIPTION
Develop a recently-used-list class to hold strings uniquely in
Last-In-First-Out order.

- A recently-used-list is initially empty.
- The most recently added item is first, the leastrecently added item is
last.
- Items can be looked up by index, which counts from zero.
- Items in the list are unique, so duplicate insertions are moved rather
than added.

Optional extras:

- Null insertions (empty strings) are not allowed.
- A bounded capacity can be specified, so there is an upper limit to the
number of items contained, with the least recently added items dropped
on overflow.